### PR TITLE
Add script for fetching Poolz configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ This repository is currently minimal and will be expanded with examples and
 helper functions.
 
 This is a [Vite](https://vitejs.dev) project bootstrapped with [`create-wagmi`](https://github.com/wevm/wagmi/tree/main/packages/create-wagmi).
+
+## Updating supported wallets and chains
+
+Run `npm run update-poolz` to fetch the latest wallet list and chain IDs from
+`https://data.poolz.finance/graphql`. The script writes the information to
+`src/poolzData.ts`.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "biome check .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "update-poolz": "node scripts/updatePoolzData.js"
   },
   "dependencies": {
     "@tanstack/react-query": "5.45.1",

--- a/scripts/updatePoolzData.js
+++ b/scripts/updatePoolzData.js
@@ -1,0 +1,53 @@
+import { writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+const query = `query Chain($sort: [String]) {
+  chains {
+    chainId
+  }
+  defaultWallets(sort: $sort) {
+    Icon {
+      url
+    }
+    Link
+    Name
+  }
+}`
+
+async function fetchPoolzData() {
+  const res = await fetch('https://data.poolz.finance/graphql', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query, variables: { sort: 'order' } }),
+  })
+  if (!res.ok) {
+    throw new Error(`Unexpected response ${res.status} ${res.statusText}`)
+  }
+  const json = await res.json()
+  return json.data
+}
+
+async function main() {
+  const data = await fetchPoolzData()
+  const chains = data.chains.map((c) => c.chainId)
+  const wallets = data.defaultWallets.map((w) => ({
+    name: w.Name,
+    link: w.Link,
+    iconUrl: w.Icon.url,
+  }))
+  const content =
+    `export const poolzChains = ${JSON.stringify(chains, null, 2)} as const;\n` +
+    `export const poolzWallets = ${JSON.stringify(wallets, null, 2)} as const;\n`
+  const outFile = path.resolve(__dirname, '../src/poolzData.ts')
+  await writeFile(outFile, content)
+  console.log(`Wrote data to ${outFile}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})
+

--- a/src/poolzData.ts
+++ b/src/poolzData.ts
@@ -1,0 +1,3 @@
+export const poolzChains = [] as const
+export const poolzWallets = [] as const
+

--- a/src/wagmi.ts
+++ b/src/wagmi.ts
@@ -1,25 +1,18 @@
 import { http, createConfig } from 'wagmi'
 import { mainnet, sepolia } from 'wagmi/chains'
 import { coinbaseWallet, injected, walletConnect } from 'wagmi/connectors'
-import { poolzChains } from './poolzData.ts'
-
-const knownChains = {
-  [mainnet.id]: mainnet,
-  [sepolia.id]: sepolia,
-}
-
-const chains = poolzChains.map((id) => knownChains[id]).filter(Boolean)
-
-if (chains.length === 0) chains.push(mainnet, sepolia)
 
 export const config = createConfig({
-  chains,
+  chains: [mainnet, sepolia],
   connectors: [
     injected(),
     coinbaseWallet(),
     walletConnect({ projectId: import.meta.env.VITE_WC_PROJECT_ID }),
   ],
-  transports: Object.fromEntries(chains.map((c) => [c.id, http()])),
+  transports: {
+    [mainnet.id]: http(),
+    [sepolia.id]: http(),
+  },
 })
 
 declare module 'wagmi' {

--- a/src/wagmi.ts
+++ b/src/wagmi.ts
@@ -1,18 +1,25 @@
 import { http, createConfig } from 'wagmi'
 import { mainnet, sepolia } from 'wagmi/chains'
 import { coinbaseWallet, injected, walletConnect } from 'wagmi/connectors'
+import { poolzChains } from './poolzData.ts'
+
+const knownChains = {
+  [mainnet.id]: mainnet,
+  [sepolia.id]: sepolia,
+}
+
+const chains = poolzChains.map((id) => knownChains[id]).filter(Boolean)
+
+if (chains.length === 0) chains.push(mainnet, sepolia)
 
 export const config = createConfig({
-  chains: [mainnet, sepolia],
+  chains,
   connectors: [
     injected(),
     coinbaseWallet(),
     walletConnect({ projectId: import.meta.env.VITE_WC_PROJECT_ID }),
   ],
-  transports: {
-    [mainnet.id]: http(),
-    [sepolia.id]: http(),
-  },
+  transports: Object.fromEntries(chains.map((c) => [c.id, http()])),
 })
 
 declare module 'wagmi' {


### PR DESCRIPTION
## Summary
- fetch chains and wallets from data.poolz.finance
- generate `src/poolzData.ts`
- wire generated data into wagmi config
- document update script in README

## Testing
- `npm run lint` *(fails: biome not found)*
- `npm run update-poolz` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_685bc8596fe48330bd83c81bb05c4ace