### PR TITLE
Add wagmi contract generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ TypeScript constants to two files: `generated/poolzChains.ts` and
 
 Run `pnpm get-abi <documentId>` to download a contract ABI from
 `https://data.poolz.finance/graphql`. The file will be saved under
-`generated/abi/` using the contract's `NameVersion` as the filename.
-A Wagmi contract file with the same name will also be generated in
-`generated/contracts/`.
+`generated/abi/` using the contract's name (without the version) as the
+filename. A Wagmi contract file with the same base name will also be generated
+in `generated/contracts/`.

--- a/README.md
+++ b/README.md
@@ -27,3 +27,5 @@ TypeScript constants to two files: `generated/poolzChains.ts` and
 Run `pnpm get-abi <documentId>` to download a contract ABI from
 `https://data.poolz.finance/graphql`. The file will be saved under
 `generated/abi/` using the contract's `NameVersion` as the filename.
+A Wagmi contract file with the same name will also be generated in
+`generated/contracts/`.

--- a/generated/poolzChains.ts
+++ b/generated/poolzChains.ts
@@ -1,12 +1,1 @@
-export const poolzChains = [
-  1,
-  56,
-  137,
-  128,
-  97,
-  42,
-  80001,
-  256,
-  43114,
-  43113
-] as const;
+export const poolzChains = [1, 56, 137, 128, 97, 42, 80001, 256, 43114, 43113] as const;

--- a/generated/poolzWallets.ts
+++ b/generated/poolzWallets.ts
@@ -2,21 +2,21 @@ export const poolzWallets = [
   {
     name: "MetaMask",
     link: "https://metamask.io/download",
-    iconUrl: "https://uplifting-bat-5a97924ca7.media.strapiapp.com/Meta_9c6f8f0cf8.svg"
+    iconUrl: "https://uplifting-bat-5a97924ca7.media.strapiapp.com/Meta_9c6f8f0cf8.svg",
   },
   {
     name: "Binance",
     link: "https://www.binance.com/en/binancewallet",
-    iconUrl: "https://uplifting-bat-5a97924ca7.media.strapiapp.com/binance_283a8da252.svg"
+    iconUrl: "https://uplifting-bat-5a97924ca7.media.strapiapp.com/binance_283a8da252.svg",
   },
   {
     name: "Coinbase",
     link: "https://www.coinbase.com/wallet",
-    iconUrl: "https://uplifting-bat-5a97924ca7.media.strapiapp.com/coinbase_8ec72cc989.svg"
+    iconUrl: "https://uplifting-bat-5a97924ca7.media.strapiapp.com/coinbase_8ec72cc989.svg",
   },
   {
     name: "Trust",
     link: "https://trustwallet.com/download",
-    iconUrl: "https://uplifting-bat-5a97924ca7.media.strapiapp.com/trust_a4c8e01095.svg"
-  }
+    iconUrl: "https://uplifting-bat-5a97924ca7.media.strapiapp.com/trust_a4c8e01095.svg",
+  },
 ] as const;

--- a/scripts/getAbi.js
+++ b/scripts/getAbi.js
@@ -63,7 +63,7 @@ export default defineConfig({
 `;
   await writeFile(wagmiConfig, wagmiConfigContent);
   await new Promise((resolve, reject) => {
-    const child = spawn(path.resolve(__dirname, "../node_modules/.bin/wagmi"), ["generate", "--config", wagmiConfig], {
+    const child = spawn("npx", ["wagmi", "generate", "--config", wagmiConfig], {
       stdio: "inherit",
     });
     child.on("exit", (code) => {

--- a/scripts/getAbi.js
+++ b/scripts/getAbi.js
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { mkdir, unlink, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -62,10 +63,11 @@ export default defineConfig({
 })
 `;
   await writeFile(wagmiConfig, wagmiConfigContent);
+  const require = createRequire(import.meta.url);
+  const wagmiCli = require.resolve("@wagmi/cli/dist/esm/cli.js");
   await new Promise((resolve, reject) => {
-    const child = spawn("npx", ["wagmi", "generate", "--config", wagmiConfig], {
-      stdio: "inherit",
-    });
+    const child = spawn(process.execPath, [wagmiCli, "generate", "--config", wagmiConfig], { stdio: "inherit" });
+    child.on("error", reject);
     child.on("exit", (code) => {
       if (code === 0) resolve();
       else reject(new Error(`wagmi exited with code ${code}`));

--- a/scripts/getAbi.js
+++ b/scripts/getAbi.js
@@ -44,21 +44,22 @@ async function main() {
 
   const outDir = path.resolve(__dirname, "../generated/abi");
   await mkdir(outDir, { recursive: true });
-  const outFile = path.join(outDir, `${contract.NameVersion}.json`);
+  const baseName = contract.NameVersion.split("@")[0];
+  const outFile = path.join(outDir, `${baseName}.json`);
   await writeFile(outFile, `${JSON.stringify(contract.ABI, null, 2)}\n`);
   console.log(`Wrote ABI to ${outFile}`);
 
-  const wagmiConfig = path.resolve(__dirname, `../generated/${contract.NameVersion}.wagmi.config.js`);
+  const wagmiConfig = path.resolve(__dirname, `../generated/${baseName}.wagmi.config.js`);
   const contractsDir = path.resolve(__dirname, "../generated/contracts");
   await mkdir(contractsDir, { recursive: true });
-  const wagmiOutFile = `generated/contracts/${contract.NameVersion}.ts`;
+  const wagmiOutFile = `generated/contracts/${baseName}.ts`;
   const wagmiConfigContent = `import { defineConfig } from '@wagmi/cli'
 import { react } from '@wagmi/cli/plugins'
-import abi from './abi/${contract.NameVersion}.json' assert { type: 'json' }
+import abi from './abi/${baseName}.json' assert { type: 'json' }
 
 export default defineConfig({
   out: '${wagmiOutFile}',
-  contracts: [{ name: '${contract.NameVersion}', abi }],
+  contracts: [{ name: '${baseName}', abi }],
   plugins: [react()],
 })
 `;
@@ -74,7 +75,7 @@ export default defineConfig({
     });
   });
   await unlink(wagmiConfig).catch(() => {});
-  console.log(`Wrote wagmi contract to ${path.join(contractsDir, `${contract.NameVersion}.ts`)}`);
+  console.log(`Wrote wagmi contract to ${path.join(contractsDir, `${baseName}.ts`)}`);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- extend `get-abi` script to create a wagmi contract file after fetching an ABI
- document new behaviour in the README

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685c048d91108330a2eb24346e6120c0