### PR TITLE
Improve example token table display

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import type { Abi } from "viem";
+import { erc20Abi, formatUnits } from "viem";
 import { useAccount, useConnect, useDisconnect, useReadContract, useReadContracts } from "wagmi";
 import { contractsByChain } from "../../src/contracts";
 import type { config } from "../../src/wagmi";
@@ -66,6 +67,57 @@ function App() {
     query: { enabled: fullDataCalls.length > 0 },
   });
 
+  const tokenAddresses = useMemo(() => {
+    const set = new Set<string>();
+    if (fullData.data) {
+      for (const res of fullData.data) {
+        const infos = res.result as { token: string }[] | undefined;
+        if (infos) {
+          for (const info of infos) {
+            set.add(info.token);
+          }
+        }
+      }
+    }
+    return Array.from(set);
+  }, [fullData.data]);
+
+  const tokenInfoCalls = useMemo(
+    () =>
+      tokenAddresses.flatMap((addr) => [
+        {
+          address: addr as `0x${string}`,
+          abi: erc20Abi,
+          functionName: "symbol",
+          chainId: account.chainId as ChainId | undefined,
+        },
+        {
+          address: addr as `0x${string}`,
+          abi: erc20Abi,
+          functionName: "decimals",
+          chainId: account.chainId as ChainId | undefined,
+        },
+      ]),
+    [tokenAddresses, account.chainId],
+  );
+
+  const tokenInfo = useReadContracts({
+    contracts: tokenInfoCalls,
+    query: { enabled: tokenInfoCalls.length > 0 },
+  });
+
+  const tokenInfoMap = useMemo(() => {
+    const map: Record<string, { symbol: string; decimals: number }> = {};
+    if (tokenInfo.data) {
+      for (let i = 0; i < tokenAddresses.length; i++) {
+        const symbol = tokenInfo.data[i * 2]?.result as string | undefined;
+        const decimals = tokenInfo.data[i * 2 + 1]?.result as number | undefined;
+        if (symbol && decimals !== undefined) map[tokenAddresses[i]] = { symbol, decimals };
+      }
+    }
+    return map;
+  }, [tokenInfo.data, tokenAddresses]);
+
   const stringifyBigInt = (value: unknown) =>
     JSON.stringify(value, (_, v) => (typeof v === "bigint" ? v.toString() : v), 2);
 
@@ -109,12 +161,11 @@ function App() {
               <tr>
                 <th>NFT ID</th>
                 <th>Provider</th>
-                <th>Name</th>
                 <th>Pool ID</th>
                 <th>Vault ID</th>
-                <th>Owner</th>
                 <th>Token</th>
-                <th>Params</th>
+                <th>Amount</th>
+                <th>Date</th>
               </tr>
             </thead>
             <tbody>
@@ -132,18 +183,34 @@ function App() {
                     }[]
                   | undefined;
                 return id !== undefined && infos
-                  ? infos.map((info, j) => (
-                      <tr key={`${id.toString()}-${j}`}>
-                        <td>{id.toString()}</td>
-                        <td>{info.provider}</td>
-                        <td>{info.name}</td>
-                        <td>{info.poolId.toString()}</td>
-                        <td>{info.vaultId.toString()}</td>
-                        <td>{info.owner}</td>
-                        <td>{info.token}</td>
-                        <td>{info.params.map((p) => p.toString()).join(", ")}</td>
-                      </tr>
-                    ))
+                  ? infos.map((info, j) => {
+                      const meta = tokenInfoMap[info.token];
+                      return (
+                        <tr key={`${id.toString()}-${j}`}>
+                          <td>{id.toString()}</td>
+                          <td>
+                            <details>
+                              <summary>{info.name}</summary>
+                              {info.provider}
+                            </details>
+                          </td>
+                          <td>{info.poolId.toString()}</td>
+                          <td>
+                            <details>
+                              <summary>show</summary>
+                              {info.vaultId.toString()}
+                            </details>
+                          </td>
+                          <td>{meta ? meta.symbol : info.token}</td>
+                          <td>
+                            {meta
+                              ? `${formatUnits(info.params[0], meta.decimals)} ${meta.symbol}`
+                              : info.params[0].toString()}
+                          </td>
+                          <td>{new Date(Number(info.params[1]) * 1000).toLocaleString()}</td>
+                        </tr>
+                      );
+                    })
                   : null;
               })}
             </tbody>

--- a/example/src/index.css
+++ b/example/src/index.css
@@ -33,6 +33,8 @@ td {
 
 th {
   text-align: left;
+}
+
 body {
   margin: 0;
   display: flex;


### PR DESCRIPTION
## Summary
- display token symbol & amount nicely
- hide provider/vault details in collapsible rows
- fix misformatted CSS table styles

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685d32035cd08330ba13b6ec48c9c6d7