### PR TITLE
Handle missing VITE_WC_PROJECT_ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,9 @@ Run `pnpm update-poolz` to fetch contract information from
 chain IDs to `generated/poolzChains.ts`, stores all contract ABIs under
 `generated/abi/` and creates contract configuration files in `src/contracts/`.
 It also updates `src/wagmi.ts` to include the retrieved chains.
+
+## Configuration
+
+`src/wagmi.ts` expects the environment variable `VITE_WC_PROJECT_ID` to be set.
+If it is missing, the module throws an error on startup so WalletConnect cannot
+be misconfigured.

--- a/src/wagmi.ts
+++ b/src/wagmi.ts
@@ -16,9 +16,15 @@ import {
 } from "wagmi/chains";
 import { coinbaseWallet, injected, walletConnect } from "wagmi/connectors";
 
+const walletConnectProjectId = import.meta.env.VITE_WC_PROJECT_ID;
+
+if (!walletConnectProjectId) {
+  throw new Error("VITE_WC_PROJECT_ID environment variable is required");
+}
+
 export const config = createConfig({
   chains: [telos, base, polygon, moonbeam, avalanche, mantaTestnet, manta, mainnet, arbitrum, sepolia, bscTestnet, bsc], //poolz chains
-  connectors: [injected(), coinbaseWallet(), walletConnect({ projectId: import.meta.env.VITE_WC_PROJECT_ID })],
+  connectors: [injected(), coinbaseWallet(), walletConnect({ projectId: walletConnectProjectId })],
   client({ chain }) {
     return createClient({ chain, transport: http() });
   },


### PR DESCRIPTION
## Summary
- enforce `VITE_WC_PROJECT_ID` in `src/wagmi.ts`
- document environment variable in README

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685e6743f6b48330aa1c00e2cab4d99a