### PR TITLE
Fix gas fee precision

### DIFF
--- a/src/hooks/useCheckGasFee.ts
+++ b/src/hooks/useCheckGasFee.ts
@@ -36,7 +36,7 @@ export function useCheckGasFee(params: PoolzGasCheckParams) {
         account,
       });
       const gasFee = new Decimal(gasEstimated.toString())
-        .times(Number(gasPrice))
+        .times(new Decimal(gasPrice.toString()))
         .toString();
 
       if (!isEnoughGasFee(String(balance), gasFee)) {


### PR DESCRIPTION
## Summary
- compute gasFee with Decimal for gas price too
- keep full precision without `Number()` conversion

## Testing
- `pnpm lint` *(fails: Found 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ec07ced6c8330afd17f56dff13915