### PR TITLE
Rename gasPrice param to gasFee

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -13,11 +13,11 @@ export const isEnoughBalance = (
 
 export const isEnoughGasFee = (
   balance: string,
-  gasPrice: string,
+  gasFee: string,
   decimals: number = 18
 ) => {
   const _balance = new Decimal(formatUnits(BigInt(balance), decimals));
-  const _gasPrice = new Decimal(formatUnits(BigInt(gasPrice), decimals));
+  const _gasFee = new Decimal(formatUnits(BigInt(gasFee), decimals));
 
-  return !_gasPrice.greaterThan(_balance);
+  return !_gasFee.greaterThan(_balance);
 };


### PR DESCRIPTION
## Summary
- rename `isEnoughGasFee` parameter from `gasPrice` to `gasFee`
- adjust usage in hooks

## Testing
- `pnpm lint` *(fails: Formatter would have printed the following content)*

------
https://chatgpt.com/codex/tasks/task_e_685ec07d2624833093da55a9945d3f5c